### PR TITLE
Docker-Compose setup: nginx crashes if loaded before PHP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       - ./:/var/www/html
       - ./docker/nginx/conf.d:/etc/nginx/conf.d
+    depends_on:
+      - php-fpm
 
   php-fpm:
     build: ./docker/php7


### PR DESCRIPTION
If the order of images is not set, nginx may load before php. This is a problem and causing crashes sometimes. With the changes contributed, nginx will wait for php image.