### PR TITLE
Accept query parameters for Integration test

### DIFF
--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -21,11 +21,12 @@ class TestCase extends PHPUnit_TestCase
     protected function createRequest(
         string $method,
         string $path,
+        string $query = '',
         array $headers = ['HTTP_ACCEPT' => 'application/json'],
         array $cookies = [],
         array $serverParams = []
     ): SlimRequest {
-        $uri = new Uri('', '', 80, $path);
+        $uri = new Uri('', '', 80, $path, $query);
         $handle = fopen('php://temp', 'w+');
         $stream = (new StreamFactory())->createStreamFromResource($handle);
 


### PR DESCRIPTION
Now If you have url with Query parameters is possible testing

Example:

```
public function testGetOneDataWeb()
{
    $req = $this->createRequest('GET', '/v1/crm/web/configuracion', 'options=analytics');
    $response = $this->getAppInstance()->handle($req);

    $this->assertEquals(200, $response->getStatusCode());
    $result = json_decode((string) $response->getBody());
    $this->assertEquals(1, count((array)$result));
}
```