### PR TITLE
Abandoned Packages Updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "maurobonfietti/skel-api-slim-php-crud-generator": "dev-master",
-        "nunomaduro/phpinsights": "^1.14",
+        "nunomaduro/phpinsights": "^2.0",
         "phpunit/phpunit": "^9.0",
         "symfony/console": "^4.4"
     },


### PR DESCRIPTION
Great package to get started with slim 4 and APIs.

While setting up this I noticed the following errors:
```
Package object-calisthenics/phpcs-calisthenics-rules is abandoned, you should avoid using it. Use symplify/phpstan-rules instead.
Package sebastian/finder-facade is abandoned, you should avoid using it. No replacement was suggested.
```
These were dependencies of nunomaduro/phpinsights v1.14.1
On researching I found that nunomaduro/phpinsights has made some changes and has now released v2.0.1

I have updated the composer.json as shown below:
`        "nunomaduro/phpinsights": "^2.0",`

Basic tests seem to work.