### PR TITLE
Remove hard coded class constants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+API_NAME='slim4-api-skeleton'
+API_VERSION='0.1.0'
+API_ENV='development'
+
 DB_HOST='127.0.0.1'
 DB_NAME='slim4_api_skeleton'
 DB_USER='root'

--- a/src/Controller/Home.php
+++ b/src/Controller/Home.php
@@ -11,9 +11,9 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 final class Home
 {
-    private const API_NAME = 'slim4-api-skeleton';
+    private const API_NAME = $_ENV['API_NAME'];
 
-    private const API_VERSION = '0.36.0';
+    private const API_VERSION = $_ENV['API_VERSION'];
 
     private Container $container;
 


### PR DESCRIPTION
Remove the ability for users to cast hard coded strings for `API_NAME` and `API_VERSION` by referencing the environment file.